### PR TITLE
feat (DOCS-CODE-007): [client-credential-flow] .NET (C#) web API

### DIFF
--- a/src/msal-client-credentials-flow/Api.csproj
+++ b/src/msal-client-credentials-flow/Api.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.*" />
+  </ItemGroup>
+
+</Project>

--- a/src/msal-client-credentials-flow/Program.cs
+++ b/src/msal-client-credentials-flow/Program.cs
@@ -13,10 +13,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddDownstreamWebApi("GraphApi", builder.Configuration.GetSection("GraphApi"));
 // </ms_docref_add_msal>
 
-// <ms_docref_enable_authz_capabilities>
 WebApplication app = builder.Build();
-app.UseAuthentication();
-// </ms_docref_enable_authz_capabilities>
 
 // <ms_docref_protect_endpoint>
 app.MapGet("/application", async (IDownstreamWebApi downstreamWebApi) => await downstreamWebApi.CallWebApiForAppAsync("GraphApi"));

--- a/src/msal-client-credentials-flow/Program.cs
+++ b/src/msal-client-credentials-flow/Program.cs
@@ -11,13 +11,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .EnableTokenAcquisitionToCallDownstreamApi()
                 .AddInMemoryTokenCaches()
                 .AddDownstreamWebApi("GraphApi", builder.Configuration.GetSection("GraphApi"));
-builder.Services.AddAuthorization();
 // </ms_docref_add_msal>
 
 // <ms_docref_enable_authz_capabilities>
 WebApplication app = builder.Build();
 app.UseAuthentication();
-app.UseAuthorization();
 // </ms_docref_enable_authz_capabilities>
 
 // <ms_docref_protect_endpoint>

--- a/src/msal-client-credentials-flow/Program.cs
+++ b/src/msal-client-credentials-flow/Program.cs
@@ -16,7 +16,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 WebApplication app = builder.Build();
 
 // <ms_docref_protect_endpoint>
-app.MapGet("/application", async (IDownstreamWebApi downstreamWebApi) =>
+app.MapGet("api/application", async (IDownstreamWebApi downstreamWebApi) =>
     {
       using var response = await downstreamWebApi.CallWebApiForAppAsync("GraphApi").ConfigureAwait(false);
 

--- a/src/msal-client-credentials-flow/Program.cs
+++ b/src/msal-client-credentials-flow/Program.cs
@@ -1,0 +1,27 @@
+// <ms_docref_import_types>
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Identity.Web;
+// </ms_docref_import_types>
+
+// <ms_docref_add_msal>
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
+                .EnableTokenAcquisitionToCallDownstreamApi()
+                .AddInMemoryTokenCaches()
+                .AddDownstreamWebApi("GraphApi", builder.Configuration.GetSection("GraphApi"));
+builder.Services.AddAuthorization();
+// </ms_docref_add_msal>
+
+// <ms_docref_enable_authz_capabilities>
+WebApplication app = builder.Build();
+app.UseAuthentication();
+app.UseAuthorization();
+// </ms_docref_enable_authz_capabilities>
+
+// <ms_docref_protect_endpoint>
+app.MapGet("/application", async (IDownstreamWebApi downstreamWebApi) => await downstreamWebApi.CallWebApiForAppAsync("GraphApi"));
+// </ms_docref_protect_endpoint>
+
+app.Run();

--- a/src/msal-client-credentials-flow/Program.cs
+++ b/src/msal-client-credentials-flow/Program.cs
@@ -16,9 +16,9 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 WebApplication app = builder.Build();
 
 // <ms_docref_protect_endpoint>
-app.MapGet("/application", async (IDownstreamWebApi _downstreamWebApi) =>
+app.MapGet("/application", async (IDownstreamWebApi downstreamWebApi) =>
     {
-      using var response = await _downstreamWebApi.CallWebApiForAppAsync("GraphApi").ConfigureAwait(false);
+      using var response = await downstreamWebApi.CallWebApiForAppAsync("GraphApi").ConfigureAwait(false);
 
       if (response.StatusCode == System.Net.HttpStatusCode.OK)
       {

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -98,7 +98,7 @@ Use these settings in your app registration.
 
 ### 2. Send request to the web API
 
-1. Once the app is listening, execute the following to send the a request.
+1. Once the app is running and listening for requests, execute the following command to send it a request.
 
    ```bash
    curl -X GET https://localhost:5001/api/application -ki

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -27,45 +27,91 @@ This ASP.NET Core minimal web API issues a call to a protected web API (Microsof
 ```console
 $ curl https://localhost:5001/api/application
 {
-  "version": "1.1",
-  "content": {
-     "headers": [
-        {
-           "key": "Content-Type",
-           "value": [
-              "application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false; charset=utf-8"
-           ]
-        }
-     ]
-  },
-  "statusCode": 200,
-  ...
-  "requestMessage": {
-     "version": "1.1",
-     "versionPolicy": 0,
-     "content": null,
-     "method": {
-        "method": "GET"
-     },
-     "requestUri": "https://graph.microsoft.com/v1.0/applications/{Azure_ActiveDirectory_Application_Object_Id}}/",
-     "headers": [
-        {
-           "key": "Authorization",
-           "value": [
-              "Bearer {SecurityToken} }"
-           ]
-        },
-        {
-           "key": "traceparent",
-           "value": [
-              "00-b645d40fb60241223de42781aa315adb-9cdfe11ad752be83-00"
-           ]
-        }
-     ],
-     "properties": {},
-     "options": {}
-  },
-  "isSuccessStatusCode": true
+   "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
+   "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",
+   "deletedDateTime": null,
+   "appId": "5b2c581d-e3ac-415e-a770-7f16254fdbf7",
+   "applicationTemplateId": null,
+   "disabledByMicrosoftStatus": null,
+   "createdDateTime": "2022-02-23T21:35:20Z",
+   "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
+   "description": null,
+   "groupMembershipClaims": null,
+   "identifierUris": [],
+   "isDeviceOnlyAuthSupported": null,
+   "isFallbackPublicClient": null,
+   "notes": null,
+   "publisherDomain": "contoso.onmicrosoft.com",
+   "serviceManagementReference": null,
+   "signInAudience": "AzureADMyOrg",
+   "tags": [],
+   "tokenEncryptionKeyId": null,
+   "defaultRedirectUri": null,
+   "certification": null,
+   "optionalClaims": null,
+   "addIns": [],
+   "api": {
+      "acceptMappedClaims": null,
+      "knownClientApplications": [],
+      "requestedAccessTokenVersion": null,
+      "oauth2PermissionScopes": [],
+      "preAuthorizedApplications": []
+   },
+   "appRoles": [],
+   "info": {
+      "logoUrl": null,
+      "marketingUrl": null,
+      "privacyStatementUrl": null,
+      "supportUrl": null,
+      "termsOfServiceUrl": null
+   },
+   "keyCredentials": [],
+   "parentalControlSettings": {
+      "countriesBlockedForMinors": [],
+      "legalAgeGroupRule": "Allow"
+   },
+   "passwordCredentials": [
+      {
+         "customKeyIdentifier": null,
+         "displayName": "test",
+         "endDateTime": "2022-08-23T21:40:52.947Z",
+         "hint": "1Oa",
+         "keyId": "3ab516d9-4a06-4c84-a73e-e258b7fd89f8",
+         "secretText": null,
+         "startDateTime": "2022-02-23T21:40:52.947Z"
+      }
+   ],
+   "publicClient": {
+      "redirectUris": []
+   },
+   "requiredResourceAccess": [
+      {
+         "resourceAppId": "00000003-0000-0000-c000-000000000000",
+         "resourceAccess": [
+            {
+               "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+               "type": "Scope"
+            }
+         ]
+      }
+   ],
+   "verifiedPublisher": {
+      "displayName": null,
+      "verifiedPublisherId": null,
+      "addedDateTime": null
+   },
+   "web": {
+      "homePageUrl": null,
+      "logoutUrl": null,
+      "redirectUris": [],
+      "implicitGrantSettings": {
+         "enableAccessTokenIssuance": false,
+         "enableIdTokenIssuance": false
+      }
+   },
+   "spa": {
+      "redirectUris": []
+   }
 }
 ```
 ## Prerequisites
@@ -125,45 +171,91 @@ Use these settings in your app registration.
    ```console
    $ curl https://localhost:5001/api/application -ki
    {
-     "version": "1.1",
-     "content": {
-        "headers": [
-           {
-              "key": "Content-Type",
-              "value": [
-                 "application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false; charset=utf-8"
-              ]
-           }
-        ]
-     },
-     "statusCode": 200,
-     ...
-     "requestMessage": {
-        "version": "1.1",
-        "versionPolicy": 0,
-        "content": null,
-        "method": {
-           "method": "GET"
-        },
-        "requestUri": "https://graph.microsoft.com/v1.0/applications/{Azure_ActiveDirectory_Application_Object_Id}}/",
-        "headers": [
-           {
-              "key": "Authorization",
-              "value": [
-                 "Bearer {SecurityToken} }"
-              ]
-           },
-           {
-              "key": "traceparent",
-              "value": [
-                 "00-b645d40fb60241223de42781aa315adb-9cdfe11ad752be83-00"
-              ]
-           }
-        ],
-        "properties": {},
-        "options": {}
-     },
-     "isSuccessStatusCode": true
+      "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
+      "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",
+      "deletedDateTime": null,
+      "appId": "5b2c581d-e3ac-415e-a770-7f16254fdbf7",
+      "applicationTemplateId": null,
+      "disabledByMicrosoftStatus": null,
+      "createdDateTime": "2022-02-23T21:35:20Z",
+      "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
+      "description": null,
+      "groupMembershipClaims": null,
+      "identifierUris": [],
+      "isDeviceOnlyAuthSupported": null,
+      "isFallbackPublicClient": null,
+      "notes": null,
+      "publisherDomain": "contoso.onmicrosoft.com",
+      "serviceManagementReference": null,
+      "signInAudience": "AzureADMyOrg",
+      "tags": [],
+      "tokenEncryptionKeyId": null,
+      "defaultRedirectUri": null,
+      "certification": null,
+      "optionalClaims": null,
+      "addIns": [],
+      "api": {
+         "acceptMappedClaims": null,
+         "knownClientApplications": [],
+         "requestedAccessTokenVersion": null,
+         "oauth2PermissionScopes": [],
+         "preAuthorizedApplications": []
+      },
+      "appRoles": [],
+      "info": {
+         "logoUrl": null,
+         "marketingUrl": null,
+         "privacyStatementUrl": null,
+         "supportUrl": null,
+         "termsOfServiceUrl": null
+      },
+      "keyCredentials": [],
+      "parentalControlSettings": {
+         "countriesBlockedForMinors": [],
+         "legalAgeGroupRule": "Allow"
+      },
+      "passwordCredentials": [
+         {
+            "customKeyIdentifier": null,
+            "displayName": "test",
+            "endDateTime": "2022-08-23T21:40:52.947Z",
+            "hint": "1Oa",
+            "keyId": "3ab516d9-4a06-4c84-a73e-e258b7fd89f8",
+            "secretText": null,
+            "startDateTime": "2022-02-23T21:40:52.947Z"
+         }
+      ],
+      "publicClient": {
+         "redirectUris": []
+      },
+      "requiredResourceAccess": [
+         {
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "resourceAccess": [
+               {
+                  "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                  "type": "Scope"
+               }
+            ]
+         }
+      ],
+      "verifiedPublisher": {
+         "displayName": null,
+         "verifiedPublisherId": null,
+         "addedDateTime": null
+      },
+      "web": {
+         "homePageUrl": null,
+         "logoutUrl": null,
+         "redirectUris": [],
+         "implicitGrantSettings": {
+            "enableAccessTokenIssuance": false,
+            "enableIdTokenIssuance": false
+         }
+      },
+      "spa": {
+         "redirectUris": []
+      }
    }
    ```
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -76,7 +76,7 @@ Use these settings in your app registration.
 
 ### 2. Configure the web API
 
-1. Open the _~/msal-client-credentials-flow/appsettings.json_ file in your code editor and modify the following values values with those from your [app's registration in the Azure portal](https://docs.microsoft.com/azure/active-directory/develop/quickstart-configure-app-expose-web-apis):
+1. Open the _~/msal-client-credentials-flow/appsettings.json_ file in your code editor and modify the following values values with those from your [app's registration in the Azure portal](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app#register-an-application):
 
    ```json
    "ClientId": "Enter_the_Application_Id_here",

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -76,7 +76,7 @@ Use these settings in your app registration.
 
 ### 2. Configure the web API
 
-1. Open the _~/msal-client-credentials-flow/appsettings.json_ file in your code editor and modify the following values values with those from your [app's registration in the Azure portal](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app#register-an-application):
+Open the _~/msal-client-credentials-flow/appsettings.json_ file in your code editor and modify the following values values with those from your [app's registration in the Azure portal](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app#register-an-application):
 
    ```json
    "ClientId": "Enter_the_Application_Id_here",
@@ -90,7 +90,7 @@ Use these settings in your app registration.
 
 ### 1. Run the web API
 
-1. Execute the following command to get the app up and running:
+Execute the following command to get the app up and running:
 
    ```bash
    dotnet run
@@ -98,42 +98,43 @@ Use these settings in your app registration.
 
 ### 2. Send request to the web API
 
-1. Once the app is running and listening for requests, execute the following command to send it a request.
+Once the app is running and listening for requests, execute the following command to send it a request.
 
-   ```bash
-   curl -X GET https://localhost:5001/api/application -ki
-   ```
 
-   If everything worked, you should receive a response from the downstream web API (Microsoft Graph, in this case) similar to this:
+```bash
+curl -X GET https://localhost:5001/api/application -ki
+```
 
-   ```console
-   $ curl https://localhost:5001/api/application -ki
-   {
-      "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
-      "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",
-      "deletedDateTime": null,
-      "appId": "5b2c581d-e3ac-415e-a770-7f16254fdbf7",
-      "applicationTemplateId": null,
-      "disabledByMicrosoftStatus": null,
-      "createdDateTime": "2022-02-23T21:35:20Z",
-      "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
-      "description": null,
-      "groupMembershipClaims": null,
-      "identifierUris": [],
-      "isDeviceOnlyAuthSupported": null,
-      "isFallbackPublicClient": null,
-      "notes": null,
-      "publisherDomain": "contoso.onmicrosoft.com",
-      "serviceManagementReference": null,
-      "signInAudience": "AzureADMyOrg",
-      "tags": [],
-      "tokenEncryptionKeyId": null,
-      "defaultRedirectUri": null,
-      "certification": null,
-      "optionalClaims": null,
-      ...
-   }
-   ```
+If everything worked, you should receive a response from the downstream web API (Microsoft Graph, in this case) similar to this:
+
+```console
+$ curl https://localhost:5001/api/application -ki
+{
+   "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
+   "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",
+   "deletedDateTime": null,
+   "appId": "5b2c581d-e3ac-415e-a770-7f16254fdbf7",
+   "applicationTemplateId": null,
+   "disabledByMicrosoftStatus": null,
+   "createdDateTime": "2022-02-23T21:35:20Z",
+   "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
+   "description": null,
+   "groupMembershipClaims": null,
+   "identifierUris": [],
+   "isDeviceOnlyAuthSupported": null,
+   "isFallbackPublicClient": null,
+   "notes": null,
+   "publisherDomain": "contoso.onmicrosoft.com",
+   "serviceManagementReference": null,
+   "signInAudience": "AzureADMyOrg",
+   "tags": [],
+   "tokenEncryptionKeyId": null,
+   "defaultRedirectUri": null,
+   "certification": null,
+   "optionalClaims": null,
+   ...
+}
+```
 
 ## About the code
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -1,0 +1,170 @@
+<!-- Keeping yaml frontmatter commented out for now
+---
+# Metadata required by https://docs.microsoft.com/samples/browse/
+# Metadata properties: https://review.docs.microsoft.com/help/contribute/samples/process/onboarding?branch=main#add-metadata-to-readme
+languages:
+- csharp
+page_type: sample
+name: "ASP.NET Core minimal web API that makes a request to the Graph API as itself"
+description: "This ASP.NET Core minimal web API sample demonstrates how to issue a call to a protected API using the client credentials flow.  A request will be issued to Microsoft Graph using the application's own identity."
+products:
+- azure
+- azure-active-directory
+- ms-graph
+urlFragment: ms-identity-docs-code-app-csharp-webapi
+---
+-->
+
+<!-- SAMPLE ID: DOCS-CODE-009-->
+# ASP.NET Core minimal web API | Web API | Web API that accesses a protected web API (Microsoft Graph) | Microsoft identity platform
+
+<!-- Build badges here
+![Build passing.](https://img.shields.io/badge/build-passing-brightgreen.svg) ![Code coverage.](https://img.shields.io/badge/coverage-100%25-brightgreen.svg) ![License.](https://img.shields.io/badge/license-MIT-green.svg)
+-->
+
+This ASP.NET Core minimal web API issues a call to a protected web API (Microsoft Graph) by using the OAuth 2.0 client credentials flow. The request to the Microsoft Graph endpoint is issued using the ASP.NET Core minimal web API's own identity.
+
+```console
+$ curl https://localhost:5001/api/application
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
+  "id": "003c4673-d4a0-4eb6-8979-d6269e08b87e",
+  "deletedDateTime": null,
+  "appId": "c085fc22-2484-41c0-b795-2e940f51df64",
+  "applicationTemplateId": null,
+  "disabledByMicrosoftStatus": null,
+  "createdDateTime": "2021-12-17T16:45:43Z",
+  "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
+  "description": null,
+  "groupMembershipClaims": null,
+  "identifierUris": ["api://c085fc22-2484-41c0-b795-2e940f51df64"],
+  "isDeviceOnlyAuthSupported": null,
+  "isFallbackPublicClient": true,
+  "notes": null,
+  "publisherDomain": "contoso.onmicrosoft.com",
+  "serviceManagementReference": null,
+  "signInAudience": "AzureADMyOrg",
+  "tags": [],
+  "tokenEncryptionKeyId": null,
+  "defaultRedirectUri": null,
+  "certification": null,
+  "optionalClaims": null
+  ...
+}
+```
+## Prerequisites
+
+- An Azure Active Directory (Azure AD) tenant. You can [open an Azure account for free](https://azure.microsoft.com/free) to get an Azure AD instance.
+- [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
+
+## Setup
+
+### 1. Register the app
+
+First, complete the steps in [Quickstart: Register an application with the Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app) to register the web API.
+
+Use these settings in your app registration.
+
+| App registration <br/> setting    | Value for this sample app                                                    | Notes                                                                                              |
+|---------------------------------:|:------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
+| **Name**                          | `active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow`      | Suggested value for this sample. <br/> You can change the app name at any time.                    |
+| **Supported account types**       | **Accounts in this organizational directory only (Single tenant)**           | Suggested value for this sample.                                                                   |
+| **Platform type**                 | _None_                                                                       | No redirect URI required; don't select a platform.                                                                    |
+| **Client secret**                 | _**Value** of the client secret (not its ID)_                                | :warning: Record this value immediately! <br/> It's shown only _once_ (when you create it).        |
+
+> :information_source: **Bold text** in the tables above matches (or is similar to) a UI element in the Azure portal, while `code formatting` indicates a value you enter into a text box in the Azure portal.
+
+### 2. Configure the web API
+
+1. Open the _~/msal-client-credentials-flow/appsettings.json_ file in your code editor and modify the following values values with those from your [app's registration in the Azure portal](https://docs.microsoft.com/azure/active-directory/develop/quickstart-configure-app-expose-web-apis):
+
+   ```json
+   "ClientId": "Enter_the_Application_Id_here",
+   "TenantId": "Enter_the_Tenant_Info_Here",
+   "ClientSecret": "Enter_the_Application_CLient_Secret_Here",
+   ...
+   "RelativePath": "Enter_the_Application_Object_Id_Here",
+   ...
+   ```
+
+## Run the application
+
+### 1. Run the web API
+
+1. Execute the following command to get the app up and running:
+
+   ```bash
+   dotnet run
+   ```
+
+### 2. Send request to the web API
+
+1. Once the app is listening, execute the following to send the a request.
+
+   ```bash
+   curl -X GET https://localhost:5001/application -ki
+   ```
+
+   :information_source: Since the request is sent without a Bearer Token, it is expected to receive an Unauthorized response `401`. The web API is now protected
+
+   If everything worked, you should receive a response from the downstream web API (Microsoft Graph, in this case) similar to this:
+
+   ```console
+   $ curl https://localhost:5001/api/application -ki
+   {
+     "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
+     "id": "003c4673-d4a0-4eb6-8979-d6269e08b87e",
+     "deletedDateTime": null,
+     "appId": "c085fc22-2484-41c0-b795-2e940f51df64",
+     "applicationTemplateId": null,
+     "disabledByMicrosoftStatus": null,
+     "createdDateTime": "2021-12-17T16:45:43Z",
+     "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
+     "description": null,
+     "groupMembershipClaims": null,
+     "identifierUris": ["api://c085fc22-2484-41c0-b795-2e940f51df64"],
+     "isDeviceOnlyAuthSupported": null,
+     "isFallbackPublicClient": true,
+     "notes": null,
+     "publisherDomain": "contoso.onmicrosoft.com",
+     "serviceManagementReference": null,
+     "signInAudience": "AzureADMyOrg",
+     "tags": [],
+     "tokenEncryptionKeyId": null,
+     "defaultRedirectUri": null,
+     "certification": null,
+     "optionalClaims": null
+     ...
+   }
+   ```
+
+## About the code
+
+This ASP.NET Core minimal web API has a single route (_/application_) that supports anonymous access.  When the anonymous route is called, the API requests its own application object from Microsoft Graph.
+
+The Microsoft Graph response data is included in its response back to the original caller.
+
+This web API uses the following:
+
+_ [Microsoft Authentication Library (MSAL)](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-overview)
+
+## Reporting problems
+
+### Sample app not working?
+
+If you can't get the sample working, you've checked [Stack Overflow](http://stackoverflow.com/questions/tagged/msal), and you've already searched the issues in this sample's repository, open an issue report the problem.
+
+1. Search the [GitHub issues](../../issues) in the repository - your problem might already have been reported or have an answer.
+1. Nothing similar? [Open an issue](../../issues/new) that clearly explains the problem you're having running the sample app.
+
+### All other issues
+
+> :warning: WARNING: Any issue in this repository _not_ limited to running one of its sample apps will be closed without being addressed.
+
+For all other requests, see [Support and help options for developers | Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/developer-support-help-options).
+
+## Contributing
+
+If you'd like to contribute to this sample, see [CONTRIBUTING.MD](/CONTRIBUTING.md).
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -97,10 +97,8 @@ Use these settings in your app registration.
    ```json
    "ClientId": "Enter_the_Application_Id_here",
    "TenantId": "Enter_the_Tenant_Info_Here",
-   "ClientSecret": "Enter_the_Application_CLient_Secret_Here",
-   ...
+   "ClientSecret": "Enter_the_Application_CLient_Secret_Here"
    "RelativePath": "Enter_the_Application_Object_Id_Here",
-   ...
    ```
 
 ## Run the application

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -171,11 +171,7 @@ Use these settings in your app registration.
 
 This ASP.NET Core minimal web API has a single route (_/application_) that supports anonymous access.  When the anonymous route is called, the API requests its own application object from Microsoft Graph.
 
-The Microsoft Graph response data is included in its response back to the original caller.
-
-This web API uses the following:
-
-_ [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+The Microsoft Graph response data is included in its response back to the original caller. This web API uses [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet).
 
 ## Reporting problems
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -25,7 +25,7 @@ urlFragment: ms-identity-docs-code-app-csharp-webapi
 This ASP.NET Core minimal web API issues a call to a protected web API (Microsoft Graph) by using the OAuth 2.0 client credentials flow. The request to the Microsoft Graph endpoint is issued using the ASP.NET Core minimal web API's own identity.
 
 ```console
-$ curl https://localhost:5001/application
+$ curl https://localhost:5001/api/application
 {
    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
    "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",
@@ -101,13 +101,13 @@ Use these settings in your app registration.
 1. Once the app is listening, execute the following to send the a request.
 
    ```bash
-   curl -X GET https://localhost:5001/application -ki
+   curl -X GET https://localhost:5001/api/application -ki
    ```
 
    If everything worked, you should receive a response from the downstream web API (Microsoft Graph, in this case) similar to this:
 
    ```console
-   $ curl https://localhost:5001/application -ki
+   $ curl https://localhost:5001/api/application -ki
    {
       "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
       "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",
@@ -137,7 +137,7 @@ Use these settings in your app registration.
 
 ## About the code
 
-This ASP.NET Core minimal web API has a single route (_/application_) that supports anonymous access.  When the anonymous route is called, the API requests its own application object from Microsoft Graph.
+This ASP.NET Core minimal web API has a single route (_/api/application_) that supports anonymous access.  When the anonymous route is called, the API requests its own application object from Microsoft Graph.
 
 The Microsoft Graph response data is included in its response back to the original caller. This web API uses [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet).
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -175,7 +175,7 @@ The Microsoft Graph response data is included in its response back to the origin
 
 This web API uses the following:
 
-_ [Microsoft Authentication Library (MSAL)](https://docs.microsoft.com/azure/active-directory/develop/msal-overview)
+_ [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
 
 ## Reporting problems
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -27,29 +27,45 @@ This ASP.NET Core minimal web API issues a call to a protected web API (Microsof
 ```console
 $ curl https://localhost:5001/api/application
 {
-  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
-  "id": "003c4673-d4a0-4eb6-8979-d6269e08b87e",
-  "deletedDateTime": null,
-  "appId": "c085fc22-2484-41c0-b795-2e940f51df64",
-  "applicationTemplateId": null,
-  "disabledByMicrosoftStatus": null,
-  "createdDateTime": "2021-12-17T16:45:43Z",
-  "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
-  "description": null,
-  "groupMembershipClaims": null,
-  "identifierUris": ["api://c085fc22-2484-41c0-b795-2e940f51df64"],
-  "isDeviceOnlyAuthSupported": null,
-  "isFallbackPublicClient": true,
-  "notes": null,
-  "publisherDomain": "contoso.onmicrosoft.com",
-  "serviceManagementReference": null,
-  "signInAudience": "AzureADMyOrg",
-  "tags": [],
-  "tokenEncryptionKeyId": null,
-  "defaultRedirectUri": null,
-  "certification": null,
-  "optionalClaims": null
+  "version": "1.1",
+  "content": {
+     "headers": [
+        {
+           "key": "Content-Type",
+           "value": [
+              "application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false; charset=utf-8"
+           ]
+        }
+     ]
+  },
+  "statusCode": 200,
   ...
+  "requestMessage": {
+     "version": "1.1",
+     "versionPolicy": 0,
+     "content": null,
+     "method": {
+        "method": "GET"
+     },
+     "requestUri": "https://graph.microsoft.com/v1.0/applications/{Azure_ActiveDirectory_Application_Object_Id}}/",
+     "headers": [
+        {
+           "key": "Authorization",
+           "value": [
+              "Bearer {SecurityToken} }"
+           ]
+        },
+        {
+           "key": "traceparent",
+           "value": [
+              "00-b645d40fb60241223de42781aa315adb-9cdfe11ad752be83-00"
+           ]
+        }
+     ],
+     "properties": {},
+     "options": {}
+  },
+  "isSuccessStatusCode": true
 }
 ```
 ## Prerequisites
@@ -110,29 +126,45 @@ Use these settings in your app registration.
    ```console
    $ curl https://localhost:5001/api/application -ki
    {
-     "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
-     "id": "003c4673-d4a0-4eb6-8979-d6269e08b87e",
-     "deletedDateTime": null,
-     "appId": "c085fc22-2484-41c0-b795-2e940f51df64",
-     "applicationTemplateId": null,
-     "disabledByMicrosoftStatus": null,
-     "createdDateTime": "2021-12-17T16:45:43Z",
-     "displayName": "active-directory-dotnet-minimal-api-aspnetcore-client-credentail-flow",
-     "description": null,
-     "groupMembershipClaims": null,
-     "identifierUris": ["api://c085fc22-2484-41c0-b795-2e940f51df64"],
-     "isDeviceOnlyAuthSupported": null,
-     "isFallbackPublicClient": true,
-     "notes": null,
-     "publisherDomain": "contoso.onmicrosoft.com",
-     "serviceManagementReference": null,
-     "signInAudience": "AzureADMyOrg",
-     "tags": [],
-     "tokenEncryptionKeyId": null,
-     "defaultRedirectUri": null,
-     "certification": null,
-     "optionalClaims": null
+     "version": "1.1",
+     "content": {
+        "headers": [
+           {
+              "key": "Content-Type",
+              "value": [
+                 "application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false; charset=utf-8"
+              ]
+           }
+        ]
+     },
+     "statusCode": 200,
      ...
+     "requestMessage": {
+        "version": "1.1",
+        "versionPolicy": 0,
+        "content": null,
+        "method": {
+           "method": "GET"
+        },
+        "requestUri": "https://graph.microsoft.com/v1.0/applications/{Azure_ActiveDirectory_Application_Object_Id}}/",
+        "headers": [
+           {
+              "key": "Authorization",
+              "value": [
+                 "Bearer {SecurityToken} }"
+              ]
+           },
+           {
+              "key": "traceparent",
+              "value": [
+                 "00-b645d40fb60241223de42781aa315adb-9cdfe11ad752be83-00"
+              ]
+           }
+        ],
+        "properties": {},
+        "options": {}
+     },
+     "isSuccessStatusCode": true
    }
    ```
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -49,69 +49,7 @@ $ curl https://localhost:5001/api/application
    "defaultRedirectUri": null,
    "certification": null,
    "optionalClaims": null,
-   "addIns": [],
-   "api": {
-      "acceptMappedClaims": null,
-      "knownClientApplications": [],
-      "requestedAccessTokenVersion": null,
-      "oauth2PermissionScopes": [],
-      "preAuthorizedApplications": []
-   },
-   "appRoles": [],
-   "info": {
-      "logoUrl": null,
-      "marketingUrl": null,
-      "privacyStatementUrl": null,
-      "supportUrl": null,
-      "termsOfServiceUrl": null
-   },
-   "keyCredentials": [],
-   "parentalControlSettings": {
-      "countriesBlockedForMinors": [],
-      "legalAgeGroupRule": "Allow"
-   },
-   "passwordCredentials": [
-      {
-         "customKeyIdentifier": null,
-         "displayName": "test",
-         "endDateTime": "2022-08-23T21:40:52.947Z",
-         "hint": "1Oa",
-         "keyId": "3ab516d9-4a06-4c84-a73e-e258b7fd89f8",
-         "secretText": null,
-         "startDateTime": "2022-02-23T21:40:52.947Z"
-      }
-   ],
-   "publicClient": {
-      "redirectUris": []
-   },
-   "requiredResourceAccess": [
-      {
-         "resourceAppId": "00000003-0000-0000-c000-000000000000",
-         "resourceAccess": [
-            {
-               "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
-               "type": "Scope"
-            }
-         ]
-      }
-   ],
-   "verifiedPublisher": {
-      "displayName": null,
-      "verifiedPublisherId": null,
-      "addedDateTime": null
-   },
-   "web": {
-      "homePageUrl": null,
-      "logoutUrl": null,
-      "redirectUris": [],
-      "implicitGrantSettings": {
-         "enableAccessTokenIssuance": false,
-         "enableIdTokenIssuance": false
-      }
-   },
-   "spa": {
-      "redirectUris": []
-   }
+   ...
 }
 ```
 ## Prerequisites
@@ -193,69 +131,7 @@ Use these settings in your app registration.
       "defaultRedirectUri": null,
       "certification": null,
       "optionalClaims": null,
-      "addIns": [],
-      "api": {
-         "acceptMappedClaims": null,
-         "knownClientApplications": [],
-         "requestedAccessTokenVersion": null,
-         "oauth2PermissionScopes": [],
-         "preAuthorizedApplications": []
-      },
-      "appRoles": [],
-      "info": {
-         "logoUrl": null,
-         "marketingUrl": null,
-         "privacyStatementUrl": null,
-         "supportUrl": null,
-         "termsOfServiceUrl": null
-      },
-      "keyCredentials": [],
-      "parentalControlSettings": {
-         "countriesBlockedForMinors": [],
-         "legalAgeGroupRule": "Allow"
-      },
-      "passwordCredentials": [
-         {
-            "customKeyIdentifier": null,
-            "displayName": "test",
-            "endDateTime": "2022-08-23T21:40:52.947Z",
-            "hint": "1Oa",
-            "keyId": "3ab516d9-4a06-4c84-a73e-e258b7fd89f8",
-            "secretText": null,
-            "startDateTime": "2022-02-23T21:40:52.947Z"
-         }
-      ],
-      "publicClient": {
-         "redirectUris": []
-      },
-      "requiredResourceAccess": [
-         {
-            "resourceAppId": "00000003-0000-0000-c000-000000000000",
-            "resourceAccess": [
-               {
-                  "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
-                  "type": "Scope"
-               }
-            ]
-         }
-      ],
-      "verifiedPublisher": {
-         "displayName": null,
-         "verifiedPublisherId": null,
-         "addedDateTime": null
-      },
-      "web": {
-         "homePageUrl": null,
-         "logoutUrl": null,
-         "redirectUris": [],
-         "implicitGrantSettings": {
-            "enableAccessTokenIssuance": false,
-            "enableIdTokenIssuance": false
-         }
-      },
-      "spa": {
-         "redirectUris": []
-      }
+      ...
    }
    ```
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -25,7 +25,7 @@ urlFragment: ms-identity-docs-code-app-csharp-webapi
 This ASP.NET Core minimal web API issues a call to a protected web API (Microsoft Graph) by using the OAuth 2.0 client credentials flow. The request to the Microsoft Graph endpoint is issued using the ASP.NET Core minimal web API's own identity.
 
 ```console
-$ curl https://localhost:5001/api/application
+$ curl https://localhost:5001/application
 {
    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
    "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",
@@ -107,7 +107,7 @@ Use these settings in your app registration.
    If everything worked, you should receive a response from the downstream web API (Microsoft Graph, in this case) similar to this:
 
    ```console
-   $ curl https://localhost:5001/api/application -ki
+   $ curl https://localhost:5001/application -ki
    {
       "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
       "id": "537a552c-58b7-4468-abdf-a7cbfa000dde",

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -139,7 +139,7 @@ Use these settings in your app registration.
 
 This ASP.NET Core minimal web API has a single route (_/api/application_) that supports anonymous access.  When the anonymous route is called, the API requests its own application object from Microsoft Graph.
 
-The Microsoft Graph response data is included in its response back to the original caller. This web API uses [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet).
+The result from Microsoft Graph is returned as the response of this web API. This web API uses [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet).
 
 ## Reporting problems
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -137,9 +137,9 @@ Use these settings in your app registration.
 
 ## About the code
 
-This ASP.NET Core minimal web API has a single route (_/api/application_) that supports anonymous access.  When the anonymous route is called, the API requests its own application object from Microsoft Graph.
+This ASP.NET Core minimal web API has a single route (_/api/application_) that supports anonymous access.  When a client app calls the anonymous route on this API, the API requests its own application object from Microsoft Graph and then returns that data to the client.
 
-The result from Microsoft Graph is returned as the response of this web API. This web API uses [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet).
+This web API uses [Microsoft Authentication Library (MSAL)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet).
 
 ## Reporting problems
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -98,6 +98,7 @@ Use these settings in your app registration.
    "ClientId": "Enter_the_Application_Id_here",
    "TenantId": "Enter_the_Tenant_Info_Here",
    "ClientSecret": "Enter_the_Application_CLient_Secret_Here"
+   ...
    "RelativePath": "Enter_the_Application_Object_Id_Here",
    ```
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -174,7 +174,7 @@ The Microsoft Graph response data is included in its response back to the origin
 
 This web API uses the following:
 
-_ [Microsoft Authentication Library (MSAL)](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-overview)
+_ [Microsoft Authentication Library (MSAL)](https://docs.microsoft.com/azure/active-directory/develop/msal-overview)
 
 ## Reporting problems
 

--- a/src/msal-client-credentials-flow/README.md
+++ b/src/msal-client-credentials-flow/README.md
@@ -105,8 +105,6 @@ Use these settings in your app registration.
    curl -X GET https://localhost:5001/application -ki
    ```
 
-   :information_source: Since the request is sent without a Bearer Token, it is expected to receive an Unauthorized response `401`. The web API is now protected
-
    If everything worked, you should receive a response from the downstream web API (Microsoft Graph, in this case) similar to this:
 
    ```console

--- a/src/msal-client-credentials-flow/appsettings.json
+++ b/src/msal-client-credentials-flow/appsettings.json
@@ -1,0 +1,20 @@
+{
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "ClientId": "Enter_the_Application_Id_here",
+    "TenantId": "Enter_the_Tenant_Info_Here",
+    "ClientSecret": "Enter_the_Application_Client_Secret_here"
+  },
+  "GraphApi": {
+    "BaseUrl": "https://graph.microsoft.com/v1.0/applications",
+    "RelativePath": "Enter_the_Application_Object_Id_here",
+    "Scopes": "https://graph.microsoft.com/.default"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/msal-client-credentials-flow/appsettings.json
+++ b/src/msal-client-credentials-flow/appsettings.json
@@ -1,13 +1,13 @@
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "ClientId": "Enter_the_Application_Id_here",
-    "TenantId": "Enter_the_Tenant_Info_Here",
-    "ClientSecret": "Enter_the_Application_Client_Secret_here"
+    "ClientId": "43dcb7fb-5edb-4c4a-b0c2-2b640e60a58a",
+    "TenantId": "3118968b-6097-4277-aeb6-a3c9d8dcd85f",
+    "ClientSecret": "sjH7Q~YNKQ0vFcoxQXOTuxjLaZGJvvUZ.uDeD"
   },
   "GraphApi": {
     "BaseUrl": "https://graph.microsoft.com/v1.0/applications",
-    "RelativePath": "Enter_the_Application_Object_Id_here",
+    "RelativePath": "674996fc-36c3-4dd4-8bbd-a10bb6741bfa",
     "Scopes": "https://graph.microsoft.com/.default"
   },
   "Logging": {

--- a/src/msal-client-credentials-flow/appsettings.json
+++ b/src/msal-client-credentials-flow/appsettings.json
@@ -1,13 +1,13 @@
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "ClientId": "43dcb7fb-5edb-4c4a-b0c2-2b640e60a58a",
-    "TenantId": "3118968b-6097-4277-aeb6-a3c9d8dcd85f",
-    "ClientSecret": "sjH7Q~YNKQ0vFcoxQXOTuxjLaZGJvvUZ.uDeD"
+    "ClientId": "Enter_the_Application_Id_here",
+    "TenantId": "Enter_the_Tenant_Info_Here",
+    "ClientSecret": "Enter_the_Application_Client_Secret_here"
   },
   "GraphApi": {
     "BaseUrl": "https://graph.microsoft.com/v1.0/applications",
-    "RelativePath": "674996fc-36c3-4dd4-8bbd-a10bb6741bfa",
+    "RelativePath": "Enter_the_Application_Object_Id_here",
     "Scopes": "https://graph.microsoft.com/.default"
   },
   "Logging": {


### PR DESCRIPTION
related: #508140, #508141

## WHY

we wanted to create a new ASP.NET Core 6 minimal web API tutorial written in C# for client credential flow without Managed Identities.

## WHAT Changed?

add web API
add readme

## HOW to Test?

Follow the `README.md` and you should be able to get `200` response status code from MS Graph applications Api  endpoint. You look at the code and it feels very idiomatic and native but at the same time some portions of the code are inlined to improve the user experience while reading the docs.  