### PR TITLE
Typo fix in WinForms examples

### DIFF
--- a/src/sign-in-windows-forms/MainWindow.Designer.cs
+++ b/src/sign-in-windows-forms/MainWindow.Designer.cs
@@ -128,7 +128,7 @@
             label1.Name = "label1";
             label1.Size = new System.Drawing.Size(226, 25);
             label1.TabIndex = 0;
-            label1.Text = "Micrsooft Graph Response:";
+            label1.Text = "Microsoft Graph Response:";
             // 
             // SignInCallToActionLabel
             // 

--- a/src/sign-in-windows-forms/MainWindow.cs
+++ b/src/sign-in-windows-forms/MainWindow.cs
@@ -29,7 +29,7 @@ namespace MsalExample
                     // 'Application (client) ID' of app registration in Azure portal - this value is a GUID
                     ClientId = ""
                 })
-                .WithDefaultRedirectUri() // http://localhost
+                .WithDefaultRedirectUri() // https://login.microsoftonline.com/common/oauth2/nativeclient
                 .Build();
         }
 

--- a/src/sign-in-windows-forms/MsalExample.csproj
+++ b/src/sign-in-windows-forms/MsalExample.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Typo fix (label text and comment text)
* Update to latest nuget package